### PR TITLE
fix bug: send more invalid bytes to server caused exception

### DIFF
--- a/src/main/java/com/tencent/tars/protocol/json/JsonOutputStream.java
+++ b/src/main/java/com/tencent/tars/protocol/json/JsonOutputStream.java
@@ -190,7 +190,7 @@ public class JsonOutputStream {
     }
 
     public ByteBuffer getByteBuffer(){
-        return this.os.getByteBuffer();
+        return ByteBuffer.wrap(this.os.toByteArray());
     }
 
     public JsonArray getBytesAsJsonArray() {


### PR DESCRIPTION
fix bug: send more invalid bytes to server caused exception when encoding request data